### PR TITLE
fix: fixed docs not building and added docs badge

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,6 @@ python:
     install:
         - method: pip
           path: .
+          extra_requirements:
+            - docs
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![pypi](https://img.shields.io/pypi/v/tetris?logo=pypi&logoColor=f0f0f0&style=for-the-badge)](https://pypi.org/project/tetris/)
 [![versions](https://img.shields.io/pypi/pyversions/tetris?logo=python&logoColor=f0f0f0&style=for-the-badge)](https://pypi.org/project/tetris/)
 [![build](https://img.shields.io/github/workflow/status/dzshn/python-tetris/Test%20library?logo=github&logoColor=f0f0f0&style=for-the-badge)](https://github.com/dzshn/python-tetris/actions/workflows/test.yml)
+[![docs](https://img.shields.io/readthedocs/python-tetris?style=for-the-badge)](https://python-tetris.readthedocs.io/en/latest/?badge=latest)
 [![technical-debt](https://img.shields.io/badge/contains-technical%20debt-009fef?style=for-the-badge)](https://forthebadge.com/)
 
 ---


### PR DESCRIPTION
I was going through the docs and saw that several of the past few commits weren't building:

![image](https://user-images.githubusercontent.com/74469257/171008264-b867d943-b15d-4968-bc10-1bc6114a6db2.png)

```txt
Running Sphinx v4.5.0
loading translations [en]... done
making output directory... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-tetris/envs/latest/lib/python3.9/site-packages/sphinx/cmd/build.py", line 272, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-tetris/envs/latest/lib/python3.9/site-packages/sphinx/application.py", line 256, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-tetris/envs/latest/lib/python3.9/site-packages/sphinx/application.py", line 314, in _init_builder
    self.builder.init()
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-tetris/envs/latest/lib/python3.9/site-packages/sphinx/builders/html/__init__.py", line 212, in init
    self.init_templates()
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-tetris/envs/latest/lib/python3.9/site-packages/sphinx/builders/html/__init__.py", line 260, in init_templates
    self.theme = theme_factory.create(themename)
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-tetris/envs/latest/lib/python3.9/site-packages/sphinx/theming.py", line 241, in create
    raise ThemeError(__('no theme named %r found (missing theme.conf?)') % name)
sphinx.errors.ThemeError: no theme named 'furo' found (missing theme.conf?)

Theme error:
no theme named 'furo' found (missing theme.conf?)
```
From the error message it looks like the `furo` theme isn't being installed
Digging deeper I found that 6bcfca8 was the first commit that failed to build

![image](https://user-images.githubusercontent.com/74469257/171008809-1371d2bf-0f6e-43e5-9c34-8cee31543efc.png)

[ReadTheDocs doesn't automatically install `poetry.extras` ](https://docs.readthedocs.io/en/stable/config-file/v2.html#packages:~:text=Extra%20requirements%20section%20to%20install%20in%20addition%20to%20the%20package%20dependencies.), so to fix this I added:
```txt
          extra_requirements:
            - docs
```
to `.readthedocs.yaml`
Tested locally and on a fork on ReadTheDocs, fix seems to work :D

Also, I added a docs badge on the `README` so you can easily see if the docs were succesfully built